### PR TITLE
Feat: docker container bind mount for log sharing & set docker Timezone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM node:16.14.2
 WORKDIR /app
 COPY package*.json ./
 
+ENV TZ=Asia/Seoul
+
+RUN npm install tzdata
 RUN npm install -g pm2
 RUN npm install
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - "3000:3000"
     environment:
       - NODE_ENV=development
+    volumes: 
+      - './logs:/app/logs'
     stdin_open: true
     tty: true
     depends_on:


### PR DESCRIPTION
- 컨테이너 내부 logs 폴더와 컨테이너 외부 logs 폴더를 연결함 -> 로그파일 컨테이너 밖에서도 볼 수 있음
- backend 도커 타임존을 Asia/Seoul 로 설정하도록 함