### PR TITLE
blockchain error handling, ranking system, username duplication error hanling

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ var marketRouter = require("./routes/market");
 var hatRouter = require("./routes/hat");
 var walletRouter = require("./routes/wallet");
 var questRouter = require("./routes/quest");
+var rankRouter = require("./routes/rank");
 
 const logger = require("./config/logger");
 var app = express();
@@ -48,6 +49,7 @@ app.use('/market', marketRouter);
 app.use('/hat', hatRouter);
 app.use('/wallet', walletRouter);
 app.use('/quest', questRouter);
+app.use('/rank', rankRouter);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/controllers/nft.ctrl.js
+++ b/controllers/nft.ctrl.js
@@ -121,7 +121,7 @@ exports.makeNFT = async function (req, res) {
 		try_count++;
 	}
 	if (try_count == max_try_count) {
-		await models.animal_possession.update({ nft_id: -1 }, { where: { id: animal_id } });//nft_id가 -1인 경우는 블록체인에 등록되지 않은 NFT
+		await models.animal_possession.update({ nft_id: -1 }, { where: { id: animal_id } });//nft_id가 -1인 경우는 블록체인에 등록되지 않은 것
 		return res.status(500).send(errorMsg.internalServerError);
 	}
 };

--- a/controllers/nft.ctrl.js
+++ b/controllers/nft.ctrl.js
@@ -99,21 +99,29 @@ exports.makeNFT = async function (req, res) {
 		3. save to Database
 	*/
 	logger.info(`${req.method} ${req.originalUrl}`);
-	try {
-		let { animal_id, wallet_address } = req.body;
-		let imgHash = await nftUtils.uploadIpfsImg(req.file);
-		let tokenURL = await nftUtils.uploadIpfsMeta(imgHash);
-		let nftMintResult = await nftUtils.getNft(title = 'Bluehat Animal', symbol = 'Bluehat', tokenURL, toAddr = wallet_address);
-		await models.nft.create({
-			token_id: nftMintResult['events']['Transfer']['returnValues']['tokenId'],
-			ipfs_addr: tokenURL,
-			contract_addr: nftMintResult['events']['Transfer']['address'],
-		}).then(async (newNft) => {
-			await models.animal_possession.update({ nft_id: newNft.id }, { where: { id: animal_id } });
-			return res.status(200).send(infoMsg.success);
-		});
-	} catch (e) {
-		logger.error(e);
+	var try_count = 0;
+	const max_try_count = 3; //블록체인 상에 http 요청이 정상적으로 전달되지 않은 경우 3번까지 시도
+	while (try_count < max_try_count) {
+		try {
+			let { animal_id, wallet_address } = req.body;
+			let imgHash = await nftUtils.uploadIpfsImg(req.file);
+			let tokenURL = await nftUtils.uploadIpfsMeta(imgHash);
+			let nftMintResult = await nftUtils.getNft(title = 'Bluehat Animal', symbol = 'Bluehat', tokenURL, toAddr = wallet_address);
+			await models.nft.create({
+				token_id: nftMintResult['events']['Transfer']['returnValues']['tokenId'],
+				ipfs_addr: tokenURL,
+				contract_addr: nftMintResult['events']['Transfer']['address'],
+			}).then(async (newNft) => {
+				await models.animal_possession.update({ nft_id: newNft.id }, { where: { id: animal_id } });
+				return res.status(200).send(infoMsg.success);
+			});
+		} catch (e) {
+			logger.error(e);
+		}
+		try_count++;
+	}
+	if (try_count == max_try_count) {
+		await models.animal_possession.update({ nft_id: -1 }, { where: { id: animal_id } });//nft_id가 -1인 경우는 블록체인에 등록되지 않은 NFT
 		return res.status(500).send(errorMsg.internalServerError);
 	}
 };

--- a/controllers/rank.ctrl.js
+++ b/controllers/rank.ctrl.js
@@ -1,0 +1,53 @@
+const models = require("../models");
+const errorMsg = require("../message/msg_error");
+const infoMsg = require("../message/msg_info");
+const logger = require("../config/logger");
+const { Op } = require("sequelize");
+exports.getUserRank = async function (req, res) {
+	logger.info(`${req.method} ${req.originalUrl}`);
+	//get user animal possession count
+	await models.animal_possession.findAll({
+		group: ['user_id'],
+		attributes: [
+			[models.sequelize.fn('COUNT', models.sequelize.col('animal_possession.id')), 'nft_animal_count'],
+			'user_id'
+		],
+		order: [[models.sequelize.fn('COUNT', models.sequelize.col('animal_possession.id')), 'DESC']],
+		//nft_id > 0 (NFT로 등록된 동물만)
+		where: {
+			nft_id: {
+				[Op.gt]: 0
+			}
+		},
+		raw: true
+	}).then(async (result) => {
+		console.log(result);
+		await models.user.findAll({
+			attributes: [
+				'username',
+				'id'
+			],
+			raw: true
+		}).then((result2) => {
+			//merge two result
+			result.forEach((item, index) => {
+				result2.forEach((item2, index2) => {
+					item.rank = index + 1;
+					if (item.user_id == item2.id) {
+						result[index].username = item2.username;
+					}
+				})
+			})
+			return res.status(200).send({ "data": result });
+		}).catch((err) => {
+			logger.error(`${req.method} ${req.originalUrl}` + ": " + err);
+			return res.status(500).send(errorMsg.internalServerError);
+		})
+	}
+	).catch((err) => {
+		logger.error(`${req.method} ${req.originalUrl}` + ": " + err);
+		return res
+			.status(500)
+			.send(errorMsg.internalServerError);
+	})
+};

--- a/controllers/user.ctrl.js
+++ b/controllers/user.ctrl.js
@@ -12,7 +12,6 @@ exports.addUser = async (req, res) => {
 	if (email === undefined) {
 		return res.status(400).send(errorMsg.notEnoughRequirement);
 	}
-
 	try {
 		if ((await userUtils.getAuthUser(email)) == false) {
 			throw "EMAIL_NOT_VERIFIED";
@@ -98,7 +97,7 @@ exports.getUserInfo = async (req, res) => {
 exports.editUserInfo = async (req, res) => {
 	logger.info(`${req.method} ${req.originalUrl}`);
 	const userId = req.userId;
-	const { username, email } = req.body;
+	const { username } = req.body;
 	try {
 		if (username !== undefined && userId !== undefined) {
 			await models.user.update({ username: username }, { where: { id: userId } });
@@ -107,11 +106,14 @@ exports.editUserInfo = async (req, res) => {
 			return res.status(400).send(errorMsg.notEnoughRequirement);
 		}
 	} catch (e) {
-		logger.error(`${req.method} ${req.originalUrl}` + ": " + e);
-		return res.send(500).send(errorMsg.internalServerError);
-	}
+		if (e.parent !== undefined && e.parent.code == "ER_DUP_ENTRY") {
+			return res.status(400).send(errorMsg.duplicateUsername);
+		} else {
+			logger.error(`${req.method} ${req.originalUrl}` + ": " + e);
+			return res.send(500).send(errorMsg.internalServerError);
+		}
+	};
 };
-
 
 exports.getUserCoin = async (req, res) => {
 	/*

--- a/message/msg_error.js
+++ b/message/msg_error.js
@@ -10,6 +10,10 @@ exports.duplicateInfo = {
 	msg: "dup email or wallet_address or username"
 }
 
+exports.duplicateUsername = {
+	msg: "dup username"
+}
+
 exports.fail = {
 	msg: "fail"
 }

--- a/routes/rank.js
+++ b/routes/rank.js
@@ -1,0 +1,8 @@
+var express = require("express");
+var router = express.Router();
+const rankCtrl = require("../controllers/rank.ctrl");
+const { verifyToken } = require('../middlewares/verify');
+
+router.get('/', verifyToken, rankCtrl.getUserRank);
+
+module.exports = router;


### PR DESCRIPTION
1. 블록체인 민팅 요청 실패 시 3회까지 재 요청 후 모두 실패하면 Merge된 동물의 nft_id = -1 로 설정
2. nft에 정상적으로 등록된 동물 수를 기준으로 전체 유저의 랭킹 반환
3. 변경하고자 하는 username이 이미 있는 경우에 에러 분기하여 처리